### PR TITLE
Optimize docker images

### DIFF
--- a/opentutor_classifier/Dockerfile
+++ b/opentutor_classifier/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.8-slim
 WORKDIR /opt/opentutor_classifier
 COPY . .
-RUN apt-get update && apt-get install -y git
 RUN pip install .
 WORKDIR /app
 RUN rm -rf /opt/opentutor_classifier


### PR DESCRIPTION
TLDR; shrinks opentutor-classifier docker image to 715MB from 815MB

Would be great to shrink down the size of our python docker images. 

Did a little inspecting and most of the image size goes to pip dependencies (about 493MB, overwhelmingly the ML libs) and then another 107MB for nltk packages.

![image](https://user-images.githubusercontent.com/323901/113640229-cbb1f980-962f-11eb-8f09-bd75af90464c.png)

...so those are not things we can easily change, but there was one low hanging fruit item which was a leftover install of `git` into the docker image. I think we needed it in the past when we were using some git urls requirements.txt, but seems to be no longer the case.
