### PR TITLE
fixes: use config-specific gql (no training)

### DIFF
--- a/opentutor_classifier/opentutor_classifier/api.py
+++ b/opentutor_classifier/opentutor_classifier/api.py
@@ -54,8 +54,8 @@ class GQLQueryBody(TypedDict):
 GQL_QUERY_LESSON_CONFIG = """
 query LessonConfig($lessonId: String!) {
     me {
-        trainingData(lessonId: $lessonId) {
-            config
+        config(lessonId: $lessonId) {
+            stringified
         }
     }
 }
@@ -178,8 +178,8 @@ def fetch_config(lesson: str) -> QuestionConfig:
     tdjson = __auth_gql(query_lesson_config_gql(lesson))
     if "errors" in tdjson:
         raise Exception(json.dumps(tdjson.get("errors")))
-    data = tdjson["data"]["me"]["trainingData"]
-    return dict_to_question_config(yaml.safe_load(data.get("config") or ""))
+    data = tdjson["data"]["me"]["config"]
+    return dict_to_question_config(yaml.safe_load(data.get("stringified") or ""))
 
 
 def fetch_training_data(lesson: str, url="") -> TrainingInput:

--- a/opentutor_classifier/tests/utils.py
+++ b/opentutor_classifier/tests/utils.py
@@ -221,13 +221,17 @@ def mock_gql_response(lesson: str, data_root: str, is_default_model=False):
     cfile = Path(path.join(data_root, lesson, "config.yaml"))
     dfile = Path(path.join(data_root, lesson, "training.csv"))
     training_data_prop = "allTrainingData" if is_default_model else "trainingData"
+    config_stringified = cfile.read_text() if cfile.is_file() else None
     res = {
         "data": {
             "me": {
                 training_data_prop: {
-                    "config": cfile.read_text() if cfile.is_file() else None,
+                    "config": config_stringified,
                     "training": dfile.read_text() if dfile.is_file() else None,
-                }
+                },
+                "config": {
+                    "stringified": config_stringified,
+                },
             }
         }
     }


### PR DESCRIPTION
Had been using a gql query in the past to load config that (on the server side) also fetches all training data, which is inefficient and also adds potential for unrelated errors

@dan100110 this should hopefully fix the bug on staging-atp.opentutor.info where training fails for some lessons or some lessons don't work w default classifier (launch untrained)